### PR TITLE
Refactor DigitalController's access for digital_liks

### DIFF
--- a/app/controllers/spree/digitals_controller.rb
+++ b/app/controllers/spree/digitals_controller.rb
@@ -2,34 +2,21 @@ module Spree
   class DigitalsController < Spree::StoreController
     force_ssl only: :show, if: :ssl_configured?
     rescue_from ActiveRecord::RecordNotFound, with: :resource_not_found
+    before_action :authorize_digital_link, only: :show
 
     def show
-      if attachment.present?
-        # don't authorize the link unless the file exists
-        # the logger error will help track down customer issues easier
-        if attachment_is_file?
-          if digital_link.authorize!
-            if Paperclip::Attachment.default_options[:storage] == :s3
-              redirect_to attachment.expiring_url(Spree::DigitalConfiguration[:s3_expiration_seconds]) and return
-            else
-              send_file attachment.path, filename: attachment.original_filename, type: attachment.content_type and return
-            end
-          end
-        else
-          Rails.logger.error "Missing Digital Item: #{attachment.path}"
-        end
+      if digital_link.cloud?
+        redirect_to attachment.expiring_url(Spree::DigitalConfiguration[:s3_expiration_seconds])
+      else
+        send_file attachment.path, filename: attachment.original_filename, type: attachment.content_type
       end
-
-      render :unauthorized
     end
 
     private
-      def attachment_is_file?
-        if Paperclip::Attachment.default_options[:storage] == :s3
-          attachment.exists?
-        else
-          File.file?(attachment.path)
-        end
+      def authorize_digital_link
+        # don't authorize the link unless the file exists
+        raise ActiveRecord::RecordNotFound unless attachment.present?
+        render :unauthorized unless digital_link.is_file? && digital_link.authorize!
       end
 
       def digital_link
@@ -37,7 +24,7 @@ module Spree
       end
 
       def attachment
-        @attachment ||= digital_link&.attachment
+        @attachment ||= digital_link.attachment
       end
 
       def resource_not_found

--- a/app/controllers/spree/digitals_controller.rb
+++ b/app/controllers/spree/digitals_controller.rb
@@ -16,7 +16,7 @@ module Spree
       def authorize_digital_link
         # don't authorize the link unless the file exists
         raise ActiveRecord::RecordNotFound unless attachment.present?
-        render :unauthorized unless digital_link.is_file? && digital_link.authorize!
+        render :unauthorized unless digital_link.file_exists? && digital_link.authorize!
       end
 
       def digital_link

--- a/app/models/spree/digital.rb
+++ b/app/models/spree/digital.rb
@@ -13,6 +13,10 @@ module Spree
       attachment_definitions[:attachment][:s3_headers] = { content_disposition: 'attachment' }
     end
 
+    def cloud?
+      Paperclip::Attachment.default_options[:storage] == :s3
+    end
+
     def create_drm_record(line_item)
       drm_records.create!(line_item: line_item)
     end

--- a/app/models/spree/digital_link.rb
+++ b/app/models/spree/digital_link.rb
@@ -22,7 +22,7 @@ module Spree
       attachment.exists?
     end
 
-    def is_file?
+    def file_exists?
       cloud? ? attachment.exists? : File.file?(attachment.path)
     end
 

--- a/app/models/spree/digital_link.rb
+++ b/app/models/spree/digital_link.rb
@@ -7,7 +7,7 @@ module Spree
     validates_length_of :secret, is: 30
     before_validation :set_defaults, on: :create
 
-    delegate :attachment_file_name, to: :digital
+    delegate :attachment_file_name, :cloud?, to: :digital
 
     # Can this link still be used? It is valid if it's less than 24 hours old and was not accessed more than 3 times
     def authorizable?
@@ -20,6 +20,10 @@ module Spree
 
     def ready?
       attachment.exists?
+    end
+
+    def is_file?
+      cloud? ? attachment.exists? : File.file?(attachment.path)
     end
 
     def access_limit_exceeded?

--- a/spec/controllers/digitals_controller_spec.rb
+++ b/spec/controllers/digitals_controller_spec.rb
@@ -4,43 +4,51 @@ RSpec.describe Spree::DigitalsController, type: :controller do
 
   context '#show' do
     let(:digital) { create(:digital) }
-    let(:authorized_digital_link) { create(:digital_link, digital: digital) }
+    let(:digital_link) { create(:digital_link, digital: digital) }
 
     it 'returns a 404 for a non-existent secret' do
       get :show, params: { secret: 'NotReal00000000000000000000000' }
       expect(response.status).to eq(404)
     end
 
-    it 'returns a 200 and calls send_file for link that is not a file' do
-      expect(controller).to receive(:attachment_is_file?).and_return(false)
-      expect(controller).not_to receive(:send_file)
+    context 'unauthorized' do
+      it 'returns a 200 and calls send_file for link that is not a file' do
+        expect(digital_link).not_to receive(:cloud?)
+        expect(controller).not_to receive(:send_file)
 
-      get :show, params: { secret: authorized_digital_link.secret }
-      expect(response.status).to eq(200)
-      expect(response).to render_template(:unauthorized)
+        get :show, params: { secret: digital_link.secret }
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:unauthorized)
+      end
     end
 
-    it 'returns a 200 and calls send_file for an authorized link that is a file' do
-      expect(controller).to receive(:attachment_is_file?).and_return(true)
-      expect(controller).to receive(:send_file).with(digital.attachment.path,
-                                                 filename: digital.attachment.original_filename,
-                                                 type: digital.attachment.content_type){ controller.render body: nil,
-                                                                         content_type: digital.attachment.content_type }
+    context 'authorized' do
+      before { allow(controller).to receive(:authorize_digital_link).and_return(true) }
 
-      get :show, params: { secret: authorized_digital_link.secret }
-      expect(response.status).to eq(200)
-      expect(response.header['Content-Type']).to match digital.attachment.content_type
-    end
+      it 'returns a 200 and calls send_file that is a file' do
+        expect(controller)
+          .to receive(:send_file)
+          .with(
+            digital.attachment.path,
+            filename: digital.attachment.original_filename,
+            type: digital.attachment.content_type
+          ){ controller.render body: nil, content_type: digital.attachment.content_type }
 
-    it 'redirects to s3 for an authorized link when using s3' do
-      skip 'TODO: needs a way to test without having a bucket'
-      Paperclip::Attachment.default_options[:storage] = :s3
+        get :show, params: { secret: digital_link.secret }
+        expect(response.status).to eq(200)
+        expect(response.header['Content-Type']).to match digital.attachment.content_type
+      end
 
-      expect(controller).to receive(:redirect_to)
-      expect(controller).to receive(:attachment_is_file?).and_return(true)
-      expect(controller).not_to receive(:send_file)
+      it 'redirects to s3 when using s3' do
+        skip 'TODO: needs a way to test without having a bucket'
+        Paperclip::Attachment.default_options[:storage] = :s3
 
-      get :show, params: { secret: authorized_digital_link.secret }
+        expect(controller).to receive(:redirect_to)
+        expect(controller).to receive(:attachment_is_file?).and_return(true)
+        expect(controller).not_to receive(:send_file)
+
+        get :show, params: { secret: digital_link.secret }
+      end
     end
   end
 end


### PR DESCRIPTION
**Motivation**: users could easily override `authorize_digital_link` method in their own app.
Example: registered users should have access to links without limitation, guests should have limits.